### PR TITLE
Samplerate issue

### DIFF
--- a/src/SoundProcessor.h
+++ b/src/SoundProcessor.h
@@ -11,20 +11,9 @@ public:
 	CSoundProcessor(float fSampleRate);
 	virtual ~CSoundProcessor();
 
-	/*Override this for audio processing.
-	\return float
-	*/
 	virtual float process() = 0;
 
-	/* Sets sample rate for all sound processors. 
-	*  Requires followup call to reinitialize()
-	\return Error_t
-	*/
 	virtual Error_t setSampleRate(float fNewSampleRate) = 0;
-
-	/* Returns current sample rate for sound processors.
-	\return float
-	*/
 	float getSampleRate();
 
 	

--- a/src/SoundProcessor.h
+++ b/src/SoundProcessor.h
@@ -13,7 +13,7 @@ public:
 
 	virtual float process() = 0;
 
-	virtual Error_t setSampleRate(float fNewSampleRate) = 0;
+	virtual Error_t setSampleRate(float fNewSampleRate);
 	float getSampleRate();
 
 	

--- a/src/SoundProcessor.h
+++ b/src/SoundProcessor.h
@@ -8,40 +8,36 @@
 class CSoundProcessor
 {
 public:
-	CSoundProcessor();
+	CSoundProcessor(float fSampleRate);
 	virtual ~CSoundProcessor();
+
+	/*Override this for audio processing.
+	\return float
+	*/
+	virtual float process() = 0;
 
 	/* Sets sample rate for all sound processors. 
 	*  Requires followup call to reinitialize()
 	\return Error_t
 	*/
-	static Error_t setSampleRate(float fNewSampleRate);
+	virtual Error_t setSampleRate(float fNewSampleRate) = 0;
 
 	/* Returns current sample rate for sound processors.
 	\return float
 	*/
-	static float getSampleRate();
+	float getSampleRate();
 
-	/* Override this for audio processing.
-	\return float
-	*/
-	virtual float process() = 0;
-
-	/* Override this to recalculate member variables that depend on sampling rate. 
-	\return void
-	*/
-	virtual void reinitialize() = 0;
 	
 protected:
 
-	static float s_fSampleRateInHz;
+	float m_fSampleRateInHz = 0.0f;
 
 };
 
 class CInstrument : public CSoundProcessor
 {
 public:
-	CInstrument();
+	CInstrument(float fGain, float fSampleRate);
 	virtual ~CInstrument();
 
 	Error_t setGain(float fNewGain);
@@ -49,38 +45,28 @@ public:
 
 protected:
 
-	float m_fGain;
+	float m_fGain = 0.0f;
 };
 
 class CWavetableOscillator : public CInstrument
 {
 public:
-	CWavetableOscillator(const CWavetable& wavetableToUse, float fFrequency = 440.0f, float fGain = 1.0f);
+	CWavetableOscillator(const CWavetable& wavetableToUse, float fFrequency, float fGain, float fSampleRate);
 	virtual ~CWavetableOscillator();
-	static Error_t updateConversionFactors();
 
 	Error_t setFrequency(float fNewFrequency);
 	float getFrequency() const;
 
-	/* Outputs values from selected wavetable.
-	\return float
-	*/
+	Error_t setSampleRate(float fNewSampleRate) override;
 	float process() override;
-
-	/* Resets frequency using proper sample rate 
-	\return void 
-	*/
-	void reinitialize() override;
 
 protected:
 
-	static float s_FREQ_TO_TABLEDELTA;
-	static float s_TABLEDELTA_TO_FREQ;
-
-	float m_fFrequencyInHz;
-	float m_fCurrentIndex;
-	float m_fTableDelta;
+	float m_fFrequencyInHz = 0.0f;
+	float m_fCurrentIndex = 0.0f;
+	float m_fTableDelta = 0.0f;
 	const CWavetable& m_Wavetable;
+	int m_iTableSize;
 
 };
 

--- a/src/Wavetable.h
+++ b/src/Wavetable.h
@@ -10,13 +10,16 @@ public:
 	virtual ~CWavetable() {};
 
     const float* getReadPointer(int sampleIndex = 0) const { return m_fWavetable.getReadPointer(0, sampleIndex); };
-	virtual void createWavetable() = 0;
-    static int getNumSamples() { return s_iTableSize; };
+	virtual void generateWavetable() = 0;
+    int getNumSamples() const { return s_iTableSize; };
+    bool hasBeenGenerated() const { return m_bHasBeenGenerated; };
+
 
 protected:
 
-	static const unsigned s_iTableSize = 1 << 9;
+	const unsigned s_iTableSize = 1 << 9;
     juce::AudioSampleBuffer m_fWavetable;
+    bool m_bHasBeenGenerated = false;
 
 };
 
@@ -27,11 +30,10 @@ public:
     CSineWavetable() {};
     ~CSineWavetable() {};
 
-	void createWavetable() override
+	void generateWavetable() override
 	{
         m_fWavetable.setSize(1, (int)s_iTableSize);
         float* samples = m_fWavetable.getWritePointer(0);     
-
         auto angleDelta = juce::MathConstants<double>::twoPi / (double)(s_iTableSize - 1); 
         auto currentAngle = 0.0;
 
@@ -41,6 +43,8 @@ public:
             samples[i] = (float)sample;
             currentAngle += angleDelta;
         }
+
+        m_bHasBeenGenerated = true;
 	}
 
 };


### PR DESCRIPTION
close #23 

Refactor how classes get/set sample rate. Static functions and variables have been removed and replaced with member variables/functions. The `virtual Error_t CSoundProcessor::setSampleRate(...)` function has been added that child classes can override to handle sample rate changes. This allows for a more self-contained functionality. `setSampleRate(...)` will need to be called on all pre-existing objects if a sample rate change occurs.