### PR TITLE
Implement ADSR, Scheduler, and Looper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,11 @@ target_sources(MusicalChess
         src/Main.cpp
         src/MainComponent.cpp
         src/SoundProcessor.cpp
+        src/Scheduler.cpp
         src/SoundProcessor.h
         src/Wavetable.h
-        src/ErrorDef.h)
+        src/ErrorDef.h
+        src/Scheduler.h)
 
 target_sources(Tests
     PRIVATE

--- a/src/MainComponent.cpp
+++ b/src/MainComponent.cpp
@@ -1,9 +1,26 @@
 #include "MainComponent.h"
+#include "Scheduler.h"
 
 //==============================================================================
 MainComponent::MainComponent()
 {
     setSize (600, 400);
+
+    const float fSampleRate = 44100;
+
+    CSineWavetable sine;
+    sine.generateWavetable();
+
+    CScheduler schedule(fSampleRate);
+    CInstrument* osc1 = new CWavetableOscillator(sine, 440, 1, fSampleRate);
+    CInstrument* osc2 = new CWavetableOscillator(sine, 220, 1, fSampleRate);
+
+    schedule.add(osc1, 1, 1);
+    schedule.add(osc2, 2, 1);
+    schedule.add(osc1, 3, 3);
+
+    delete osc1;
+    delete osc2;
 }
 
 //==============================================================================

--- a/src/MainComponent.cpp
+++ b/src/MainComponent.cpp
@@ -1,26 +1,9 @@
 #include "MainComponent.h"
-#include "Scheduler.h"
 
 //==============================================================================
 MainComponent::MainComponent()
 {
     setSize (600, 400);
-
-    const float fSampleRate = 44100;
-
-    CSineWavetable sine;
-    sine.generateWavetable();
-
-    CScheduler schedule(fSampleRate);
-    CInstrument* osc1 = new CWavetableOscillator(sine, 440, 1, fSampleRate);
-    CInstrument* osc2 = new CWavetableOscillator(sine, 220, 1, fSampleRate);
-
-    schedule.add(osc1, 1, 1);
-    schedule.add(osc2, 2, 1);
-    schedule.add(osc1, 3, 3);
-
-    delete osc1;
-    delete osc2;
 }
 
 //==============================================================================

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -33,10 +33,16 @@ float CScheduler::process()
 		}
 		m_ScheduleEnder.erase(EndSampleIterator);
 	}
-	iCurrentSample++;
+
+	if (m_ScheduleStarter.empty() && m_ScheduleEnder.empty())
+		iCurrentSample = 0;
+	else
+		iCurrentSample++;
+
 	float fCurrentValue = 0.0f;
 	for (CInstrument* instToProcess : m_InstrumentVector)
 		fCurrentValue += instToProcess->process();
+
 	return fCurrentValue;
 }
 

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -108,7 +108,7 @@ Error_t CScheduler::addToInstRemover(CInstrument* pInstrumentToAdd, float fOnset
 }
 Error_t CScheduler::addToSchedulers(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
 {
-	if (addToADSRSchedulers(pInstrumentToAdd, fOnsetInSec, fDurationInSec) == Error_t::kNoError);
+	if (addToADSRSchedulers(pInstrumentToAdd, fOnsetInSec, fDurationInSec) == Error_t::kNoError)
 		return addToInstRemover(pInstrumentToAdd, fOnsetInSec, fDurationInSec);
 	return Error_t::kFunctionInvalidArgsError;
 }

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -7,12 +7,14 @@ CScheduler::CScheduler(float fSampleRate) :
 
 CScheduler::~CScheduler()
 {
+	for (CInstrument* instToDelete : m_InstrumentVector)
+		delete instToDelete;
 }
 
-void CScheduler::process()
+float CScheduler::process()
 {
 	auto startSampleIterator = m_ScheduleStarter.find(iCurrentSample);
-	if (startSampleIterator != m_ScheduleEnder.end())
+	if (startSampleIterator != m_ScheduleStarter.end())
 	{
 		std::unordered_set<CInstrument*> setToStart = startSampleIterator->second;
 		for (CInstrument* instToStart : setToStart)
@@ -26,16 +28,28 @@ void CScheduler::process()
 			instToEnd->noteOff();
 	}
 	iCurrentSample++;
+	float fCurrentValue = 0.0f;
+	for (CInstrument* instToProcess : m_InstrumentVector)
+		fCurrentValue += instToProcess->process();
+	return fCurrentValue;
 }
 
-Error_t CScheduler::add(CInstrument* rInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
+Error_t CScheduler::add(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
 {
+	if (pInstrumentToAdd == nullptr || fOnsetInSec < 0 || fDurationInSec < 0)
+		return Error_t::kFunctionInvalidArgsError;
 
 	int iOnsetInSamp = convertSecToSamp(fOnsetInSec);
-	int iDurationInSamp = convertSecToSamp(fOnsetInSec);
-	m_ScheduleStarter[iCurrentSample + iOnsetInSamp].insert(rInstrumentToAdd);
-	m_ScheduleEnder[iCurrentSample + iDurationInSamp].insert(rInstrumentToAdd);
+	int iDurationInSamp = convertSecToSamp(fDurationInSec);
+	m_ScheduleStarter[iCurrentSample + iOnsetInSamp].insert(pInstrumentToAdd);
+	m_ScheduleEnder[iCurrentSample + iOnsetInSamp + iDurationInSamp].insert(pInstrumentToAdd);
+	m_InstrumentVector.push_back(pInstrumentToAdd);
 	return Error_t::kNoError;
+}
+
+Error_t CScheduler::enableLoop(bool bShouldEnable)
+{
+	return Error_t();
 }
 
 int CScheduler::convertSecToSamp(float fSec) const

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -1,129 +1,14 @@
 #include "Scheduler.h"
 
-CScheduler::CScheduler(float fSampleRate) :
-	CSoundProcessor(fSampleRate)
-{
-}
-
-CScheduler::~CScheduler()
-{
- 	reset();
-	assert(m_GarbageCollector.empty());
-}
-
-float CScheduler::process()
-{
-	auto noteOnIterator = m_ScheduleNoteOn.find(iCurrentSample);
-	if (noteOnIterator != m_ScheduleNoteOn.end())
-	{
-		std::unordered_set<CInstrument*> setToStart = noteOnIterator->second;
-		for (CInstrument* instToStart : setToStart)
-		{
-			instToStart->noteOn();
-		}
-		m_ScheduleNoteOn.erase(noteOnIterator);
-	}
-	auto noteOffIterator = m_ScheduleNoteOff.find(iCurrentSample);
-	if (noteOffIterator != m_ScheduleNoteOff.end())
-	{
-		std::unordered_set<CInstrument*> setToEnd = noteOffIterator->second;
-		for (CInstrument* instToEnd : setToEnd) 
-		{
-			instToEnd->noteOff();
-		}
-		m_ScheduleNoteOff.erase(noteOffIterator);
-	}
-	auto removeIterator = m_ScheduleRemover.find(iCurrentSample);
-	if (removeIterator != m_ScheduleRemover.end())
-	{
-		std::unordered_set<CInstrument*> setToRemove = removeIterator->second;
-		for (CInstrument* instToRemove : setToRemove)
-		{
-			m_InstrumentList.remove(instToRemove);
-		}
-		m_ScheduleRemover.erase(removeIterator);
-	}
-	iCurrentSample++;
-
-	float fCurrentValue = 0.0f;
-	for (CInstrument* instToProcess : m_InstrumentList)
-		fCurrentValue += instToProcess->process();
-
-	return fCurrentValue;
-}
-
-Error_t CScheduler::add(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
-{
-	if (m_InstrumentList.empty())
-		iCurrentSample = 0;
-	m_GarbageCollector.push_back(pInstrumentToAdd);
-	return addToSchedulers(pInstrumentToAdd, fOnsetInSec, fDurationInSec);
-}
-
-Error_t CScheduler::add(CInstrument& rInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
-{
-	CInstrument* pInstrumentToAdd = &rInstrumentToAdd;
-	return addToSchedulers(pInstrumentToAdd, fOnsetInSec, fDurationInSec);
-}
-
-Error_t CScheduler::reset()
-{
-	for (CInstrument* instToDelete : m_GarbageCollector)
-		delete instToDelete;
-	m_ScheduleNoteOn.clear();
-	m_ScheduleNoteOff.clear();
-	m_ScheduleRemover.clear();
-	m_InstrumentList.clear();
-	m_GarbageCollector.clear();
-	iCurrentSample = 0;
-	return Error_t::kNoError;
-}
-
-int CScheduler::convertSecToSamp(float fSec) const
-{
-	return static_cast<int>(fSec * m_fSampleRateInHz);
-}
-Error_t CScheduler::addToADSRSchedulers(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
-{
-	if (pInstrumentToAdd == nullptr || fOnsetInSec < 0 || fDurationInSec < 0)
-		return Error_t::kFunctionInvalidArgsError;
-
-	int iNoteOnInSamp = convertSecToSamp(fOnsetInSec);
-	int iNoteOffInSamp = iNoteOnInSamp + convertSecToSamp(fDurationInSec - pInstrumentToAdd->getADSRParameters().release);
-	assert(iNoteOffInSamp > iNoteOnInSamp);
-	if (iNoteOffInSamp < iNoteOnInSamp)
-		return Error_t::kFunctionInvalidArgsError;
-
-	m_ScheduleNoteOn[iNoteOnInSamp].insert(pInstrumentToAdd);
-	m_ScheduleNoteOff[iNoteOffInSamp].insert(pInstrumentToAdd);
-	m_InstrumentList.push_front(pInstrumentToAdd);
-
-	return Error_t::kNoError;
-}
-Error_t CScheduler::addToInstRemover(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
-{
-	int iDoneSamp = convertSecToSamp(fOnsetInSec + fDurationInSec);
-	m_ScheduleRemover[iDoneSamp].insert(pInstrumentToAdd);
-	return Error_t::kNoError;
-}
-Error_t CScheduler::addToSchedulers(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
-{
-	if (addToADSRSchedulers(pInstrumentToAdd, fOnsetInSec, fDurationInSec) == Error_t::kNoError)
-		return addToInstRemover(pInstrumentToAdd, fOnsetInSec, fDurationInSec);
-	return Error_t::kFunctionInvalidArgsError;
-}
-//==========================================================
-
 //==========================================================
 CLooper::CLooper(float fSampleRate) :
-	CScheduler(fSampleRate)
+	CSoundProcessor(fSampleRate)
 {
 }
 
 CLooper::~CLooper()
 {
 	reset();
-	assert(m_GarbageCollector.empty());
 }
 
 float CLooper::process()
@@ -175,8 +60,136 @@ Error_t CLooper::add(CInstrument& rInstrumentToAdd, float fOnsetInSec, float fDu
 	return add(pInstrumentToAdd, fOnsetInSec, fDurationInSec);
 }
 
+int CLooper::convertSecToSamp(float fSec) const
+{
+	return static_cast<int>(fSec * m_fSampleRateInHz);
+}
+int CLooper::convertSampToSec(int iSamp) const
+{
+	return static_cast<float>(iSamp / m_fSampleRateInHz);
+}
+Error_t CLooper::addToADSRSchedulers(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
+{
+	if (pInstrumentToAdd == nullptr || fOnsetInSec < 0 || fDurationInSec < 0)
+		return Error_t::kFunctionInvalidArgsError;
+
+	int iNoteOnInSamp = convertSecToSamp(fOnsetInSec) + iCurrentSample;
+	int iNoteOffInSamp = iNoteOnInSamp + convertSecToSamp(fDurationInSec - pInstrumentToAdd->getADSRParameters().release);
+	assert(iNoteOffInSamp > iNoteOnInSamp);
+	if (iNoteOffInSamp < iNoteOnInSamp)
+		return Error_t::kFunctionInvalidArgsError;
+
+	m_ScheduleNoteOn[iNoteOnInSamp].insert(pInstrumentToAdd);
+	m_ScheduleNoteOff[iNoteOffInSamp].insert(pInstrumentToAdd);
+	m_InstrumentList.push_front(pInstrumentToAdd);
+
+	return Error_t::kNoError;
+}
+
 Error_t CLooper::reset()
 {
+	for (CInstrument* instToDelete : m_GarbageCollector)
+		delete instToDelete;
+	m_ScheduleNoteOn.clear();
+	m_ScheduleNoteOff.clear();
+	m_InstrumentList.clear();
+	m_GarbageCollector.clear();
+	iCurrentSample = 0;
 	iLoopSample = 1;
-	return CScheduler::reset();
+	assert(m_GarbageCollector.empty());
+	return Error_t::kNoError;
 }
+
+//==========================================================================
+
+CScheduler::CScheduler(float fSampleRate) :
+	CLooper(fSampleRate)
+{
+}
+
+CScheduler::~CScheduler()
+{
+	reset();
+}
+
+float CScheduler::process()
+{
+	auto noteOnIterator = m_ScheduleNoteOn.find(iCurrentSample);
+	if (noteOnIterator != m_ScheduleNoteOn.end())
+	{
+		std::unordered_set<CInstrument*> setToStart = noteOnIterator->second;
+		for (CInstrument* instToStart : setToStart)
+		{
+			instToStart->noteOn();
+		}
+		m_ScheduleNoteOn.erase(noteOnIterator);
+	}
+	auto noteOffIterator = m_ScheduleNoteOff.find(iCurrentSample);
+	if (noteOffIterator != m_ScheduleNoteOff.end())
+	{
+		std::unordered_set<CInstrument*> setToEnd = noteOffIterator->second;
+		for (CInstrument* instToEnd : setToEnd) 
+		{
+			instToEnd->noteOff();
+		}
+		m_ScheduleNoteOff.erase(noteOffIterator);
+	}
+	auto removeIterator = m_ScheduleRemover.find(iCurrentSample);
+	if (removeIterator != m_ScheduleRemover.end())
+	{
+		std::unordered_set<CInstrument*> setToRemove = removeIterator->second;
+		for (CInstrument* instToRemove : setToRemove)
+		{
+			m_InstrumentList.remove(instToRemove);
+		}
+		m_ScheduleRemover.erase(removeIterator);
+	}
+	iCurrentSample++;
+
+	float fCurrentValue = 0.0f;
+	for (CInstrument* instToProcess : m_InstrumentList)
+		fCurrentValue += instToProcess->process();
+
+	return fCurrentValue;
+}
+
+Error_t CScheduler::add(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
+{
+	m_GarbageCollector.push_back(pInstrumentToAdd);
+	return addToSchedulers(pInstrumentToAdd, fOnsetInSec, fDurationInSec);
+}
+
+Error_t CScheduler::add(CInstrument& rInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
+{
+	CInstrument* pInstrumentToAdd = &rInstrumentToAdd;
+	return addToSchedulers(pInstrumentToAdd, fOnsetInSec, fDurationInSec);
+}
+
+Error_t CScheduler::reset()
+{
+	m_ScheduleRemover.clear();
+	return CLooper::reset();
+}
+
+Error_t CScheduler::addToADSRSchedulers(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
+{
+	return CLooper::addToADSRSchedulers(pInstrumentToAdd, fOnsetInSec + convertSampToSec(iCurrentSample), fDurationInSec);
+}
+
+Error_t CScheduler::addToInstRemover(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
+{
+	int iDoneSamp = convertSecToSamp(fOnsetInSec + fDurationInSec) + iCurrentSample;
+	m_ScheduleRemover[iDoneSamp].insert(pInstrumentToAdd);
+	return Error_t::kNoError;
+}
+Error_t CScheduler::addToSchedulers(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
+{
+	if (m_InstrumentList.empty())
+		iCurrentSample = 0;
+	if (addToADSRSchedulers(pInstrumentToAdd, fOnsetInSec, fDurationInSec) == Error_t::kNoError)
+		return addToInstRemover(pInstrumentToAdd, fOnsetInSec, fDurationInSec);
+	return Error_t::kFunctionInvalidArgsError;
+}
+//==========================================================
+
+

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -18,14 +18,20 @@ float CScheduler::process()
 	{
 		std::unordered_set<CInstrument*> setToStart = startSampleIterator->second;
 		for (CInstrument* instToStart : setToStart)
+		{
 			instToStart->noteOn();
+		}
+		m_ScheduleStarter.erase(startSampleIterator);
 	}
 	auto EndSampleIterator = m_ScheduleEnder.find(iCurrentSample);
 	if (EndSampleIterator != m_ScheduleEnder.end())
 	{
 		std::unordered_set<CInstrument*> setToEnd = EndSampleIterator->second;
-		for (CInstrument* instToEnd : setToEnd)
+		for (CInstrument* instToEnd : setToEnd) 
+		{
 			instToEnd->noteOff();
+		}
+		m_ScheduleEnder.erase(EndSampleIterator);
 	}
 	iCurrentSample++;
 	float fCurrentValue = 0.0f;
@@ -39,17 +45,12 @@ Error_t CScheduler::add(CInstrument* pInstrumentToAdd, float fOnsetInSec, float 
 	if (pInstrumentToAdd == nullptr || fOnsetInSec < 0 || fDurationInSec < 0)
 		return Error_t::kFunctionInvalidArgsError;
 
-	int iOnsetInSamp = convertSecToSamp(fOnsetInSec);
-	int iDurationInSamp = convertSecToSamp(fDurationInSec);
-	m_ScheduleStarter[iCurrentSample + iOnsetInSamp].insert(pInstrumentToAdd);
-	m_ScheduleEnder[iCurrentSample + iOnsetInSamp + iDurationInSamp].insert(pInstrumentToAdd);
+	int iOnsetInSamp = convertSecToSamp(fOnsetInSec) + iCurrentSample;
+	int iDurationInSamp = convertSecToSamp(fDurationInSec) + iOnsetInSamp;
+	m_ScheduleStarter[iOnsetInSamp].insert(pInstrumentToAdd);
+	m_ScheduleEnder[iDurationInSamp].insert(pInstrumentToAdd);
 	m_InstrumentVector.push_back(pInstrumentToAdd);
 	return Error_t::kNoError;
-}
-
-Error_t CScheduler::enableLoop(bool bShouldEnable)
-{
-	return Error_t();
 }
 
 int CScheduler::convertSecToSamp(float fSec) const

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -87,6 +87,7 @@ Error_t CScheduler::addToADSRSchedulers(CInstrument* pInstrumentToAdd, float fOn
 {
 	if (pInstrumentToAdd == nullptr || fOnsetInSec < 0 || fDurationInSec < 0)
 		return Error_t::kFunctionInvalidArgsError;
+
 	int iNoteOnInSamp = convertSecToSamp(fOnsetInSec);
 	int iNoteOffInSamp = iNoteOnInSamp + convertSecToSamp(fDurationInSec - pInstrumentToAdd->getADSRParameters().release);
 	assert(iNoteOffInSamp > iNoteOnInSamp);
@@ -96,6 +97,7 @@ Error_t CScheduler::addToADSRSchedulers(CInstrument* pInstrumentToAdd, float fOn
 	m_ScheduleNoteOn[iNoteOnInSamp].insert(pInstrumentToAdd);
 	m_ScheduleNoteOff[iNoteOffInSamp].insert(pInstrumentToAdd);
 	m_InstrumentList.push_front(pInstrumentToAdd);
+
 	return Error_t::kNoError;
 }
 Error_t CScheduler::addToInstRemover(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec)

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -45,10 +45,10 @@ Error_t CScheduler::add(CInstrument* pInstrumentToAdd, float fOnsetInSec, float 
 	if (pInstrumentToAdd == nullptr || fOnsetInSec < 0 || fDurationInSec < 0)
 		return Error_t::kFunctionInvalidArgsError;
 
-	int iOnsetInSamp = convertSecToSamp(fOnsetInSec) + iCurrentSample;
-	int iDurationInSamp = convertSecToSamp(fDurationInSec) + iOnsetInSamp;
-	m_ScheduleStarter[iOnsetInSamp].insert(pInstrumentToAdd);
-	m_ScheduleEnder[iDurationInSamp].insert(pInstrumentToAdd);
+	int iNoteOnInSamp = convertSecToSamp(fOnsetInSec) + iCurrentSample;
+	int iNoteOffInSamp = convertSecToSamp(fDurationInSec) + iNoteOnInSamp;
+	m_ScheduleStarter[iNoteOnInSamp].insert(pInstrumentToAdd);
+	m_ScheduleEnder[iNoteOffInSamp].insert(pInstrumentToAdd);
 	m_InstrumentVector.push_back(pInstrumentToAdd);
 	return Error_t::kNoError;
 }
@@ -56,4 +56,61 @@ Error_t CScheduler::add(CInstrument* pInstrumentToAdd, float fOnsetInSec, float 
 int CScheduler::convertSecToSamp(float fSec) const
 {
 	return static_cast<int>(fSec * m_fSampleRateInHz);
+}
+//==========================================================
+
+//==========================================================
+CLooper::CLooper(float fSampleRate) :
+	CScheduler(fSampleRate)
+{
+}
+
+CLooper::~CLooper()
+{
+
+}
+
+float CLooper::process()
+{
+	auto startSampleIterator = m_ScheduleStarter.find(iCurrentSample);
+	if (startSampleIterator != m_ScheduleStarter.end())
+	{
+		std::unordered_set<CInstrument*> setToStart = startSampleIterator->second;
+		for (CInstrument* instToStart : setToStart)
+		{
+			instToStart->noteOn();
+		}
+	}
+	auto EndSampleIterator = m_ScheduleEnder.find(iCurrentSample);
+	if (EndSampleIterator != m_ScheduleEnder.end())
+	{
+		std::unordered_set<CInstrument*> setToEnd = EndSampleIterator->second;
+		for (CInstrument* instToEnd : setToEnd)
+		{
+			instToEnd->noteOff();
+		}
+	}
+	iCurrentSample++;
+	iCurrentSample %= iLoopSample;
+	float fCurrentValue = 0.0f;
+	for (CInstrument* instToProcess : m_InstrumentVector)
+		fCurrentValue += instToProcess->process();
+	return fCurrentValue;
+}
+
+Error_t CLooper::add(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
+{
+	if (pInstrumentToAdd == nullptr || fOnsetInSec < 0 || fDurationInSec < 0)
+		return Error_t::kFunctionInvalidArgsError;
+
+	int iNoteOnInSamp = convertSecToSamp(fOnsetInSec);
+	int iNoteOffInSamp = convertSecToSamp(fDurationInSec) + iNoteOnInSamp;
+	int iTotalLength = iNoteOffInSamp + pInstrumentToAdd->getADSRParameters().release * m_fSampleRateInHz;
+	if (iTotalLength > iLoopSample)
+		iLoopSample = iTotalLength;
+	m_ScheduleStarter[iNoteOnInSamp].insert(pInstrumentToAdd);
+	m_ScheduleEnder[iNoteOffInSamp].insert(pInstrumentToAdd);
+	m_InstrumentVector.push_back(pInstrumentToAdd);
+	return Error_t::kNoError;
+
 }

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -1,0 +1,44 @@
+#include "Scheduler.h"
+
+CScheduler::CScheduler(float fSampleRate) :
+	CSoundProcessor(fSampleRate)
+{
+}
+
+CScheduler::~CScheduler()
+{
+}
+
+void CScheduler::process()
+{
+	auto startSampleIterator = m_ScheduleStarter.find(iCurrentSample);
+	if (startSampleIterator != m_ScheduleEnder.end())
+	{
+		std::unordered_set<CInstrument*> setToStart = startSampleIterator->second;
+		for (CInstrument* instToStart : setToStart)
+			instToStart->noteOn();
+	}
+	auto EndSampleIterator = m_ScheduleEnder.find(iCurrentSample);
+	if (EndSampleIterator != m_ScheduleEnder.end())
+	{
+		std::unordered_set<CInstrument*> setToEnd = EndSampleIterator->second;
+		for (CInstrument* instToEnd : setToEnd)
+			instToEnd->noteOff();
+	}
+	iCurrentSample++;
+}
+
+Error_t CScheduler::add(CInstrument* rInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
+{
+
+	int iOnsetInSamp = convertSecToSamp(fOnsetInSec);
+	int iDurationInSamp = convertSecToSamp(fOnsetInSec);
+	m_ScheduleStarter[iCurrentSample + iOnsetInSamp].insert(rInstrumentToAdd);
+	m_ScheduleEnder[iCurrentSample + iDurationInSamp].insert(rInstrumentToAdd);
+	return Error_t::kNoError;
+}
+
+int CScheduler::convertSecToSamp(float fSec) const
+{
+	return static_cast<int>(fSec * m_fSampleRateInHz);
+}

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -43,11 +43,7 @@ float CScheduler::process()
 		}
 		m_ScheduleRemover.erase(removeIterator);
 	}
-
-	if (m_ScheduleNoteOn.empty() && m_ScheduleNoteOff.empty() && m_ScheduleRemover.empty())
-		iCurrentSample = 0;
-	else
-		iCurrentSample++;
+	iCurrentSample++;
 
 	float fCurrentValue = 0.0f;
 	for (CInstrument* instToProcess : m_InstrumentList)
@@ -58,6 +54,8 @@ float CScheduler::process()
 
 Error_t CScheduler::add(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec)
 {
+	if (m_InstrumentList.empty())
+		iCurrentSample = 0;
 	m_GarbageCollector.push_back(pInstrumentToAdd);
 	return addToSchedulers(pInstrumentToAdd, fOnsetInSec, fDurationInSec);
 }

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -8,11 +8,11 @@
 
 #include "SoundProcessor.h"
 
-class CScheduler : public CSoundProcessor
+class CLooper : public CSoundProcessor
 {
 public:
-	CScheduler(float fSampleRate = 48000.0f);
-	~CScheduler();
+	CLooper(float fSampleRate = 48000.0f);
+	~CLooper();
 
 	float process() override;
 
@@ -29,19 +29,20 @@ protected:
 	std::vector<CInstrument*> m_GarbageCollector;
 
 	int convertSecToSamp(float fSec) const;
+	int convertSampToSec(int iSamp) const;
 	Error_t addToADSRSchedulers(CInstrument* pInstrumentToAdd, float fOnset, float fDurationInSec);
 
 private:
-	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleRemover;
-	Error_t addToInstRemover(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
-	Error_t addToSchedulers(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
+
+	int iLoopSample = 1;
+
 };
 
-class CLooper : public CScheduler
+class CScheduler : public CLooper
 {
 public:
-	CLooper(float fSampleRate = 48000.0f);
-	~CLooper();
+	CScheduler(float fSampleRate = 48000.0f);
+	~CScheduler();
 
 	float process() override;
 
@@ -51,7 +52,12 @@ public:
 
 private:
 
-	int iLoopSample = 1;
+	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleRemover;
 
+	Error_t addToADSRSchedulers(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
+	Error_t addToInstRemover(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
+	Error_t addToSchedulers(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
 };
+
+
 #endif // #if !defined(__Scheduler_hdr__)

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -3,23 +3,27 @@
 
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "SoundProcessor.h"
 
 class CScheduler : public CSoundProcessor
 {
 public:
-	CScheduler(float fSampleRate);
+	CScheduler(float fSampleRate = 0.0f);
 	~CScheduler();
 
-	void process();
+	float process();
 
 	Error_t add(CInstrument* rInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
+	Error_t enableLoop(bool bShouldEnable);
 
 private:
 
 	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleStarter;
 	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleEnder;
+	std::vector<CInstrument*> m_InstrumentVector;
+
 	int convertSecToSamp(float fSec) const;
 
 	int iCurrentSample = 0;

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -5,6 +5,7 @@
 #include <unordered_set>
 #include <forward_list>
 #include <vector>
+#include <tuple>
 
 #include "SoundProcessor.h"
 
@@ -17,20 +18,25 @@ public:
 	float process() override;
 
 	Error_t add(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
+	Error_t add(CInstrument& rInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
 	Error_t reset();
 
 protected:
 
-	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleStarter;
-	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleEnder;
+	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleNoteOn;
+	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleNoteOff;
 	std::forward_list<CInstrument*> m_InstrumentList;
+	std::vector<CInstrument*> m_GarbageCollector;
 
 	int convertSecToSamp(float fSec) const;
+	Error_t addToADSRSchedulers(CInstrument* pInstrumentToAdd, float fOnset, float fDurationInSec);
 
 	int iCurrentSample = 0;
 
 private:
-	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleDeleter;
+	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleRemover;
+	Error_t addToInstRemover(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
+	Error_t addToSchedulers(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
 };
 
 class CLooper : public CScheduler
@@ -42,6 +48,7 @@ public:
 	float process() override;
 
 	Error_t add(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
+	Error_t add(CInstrument& rInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
 	Error_t reset();
 
 private:

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -16,7 +16,6 @@ public:
 	float process() override;
 
 	Error_t add(CInstrument* rInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
-	Error_t enableLoop(bool bShouldEnable);
 
 private:
 

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -5,7 +5,6 @@
 #include <unordered_set>
 #include <forward_list>
 #include <vector>
-#include <tuple>
 
 #include "SoundProcessor.h"
 
@@ -23,6 +22,7 @@ public:
 
 protected:
 
+	int iCurrentSample = 0;
 	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleNoteOn;
 	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleNoteOff;
 	std::forward_list<CInstrument*> m_InstrumentList;
@@ -30,8 +30,6 @@ protected:
 
 	int convertSecToSamp(float fSec) const;
 	Error_t addToADSRSchedulers(CInstrument* pInstrumentToAdd, float fOnset, float fDurationInSec);
-
-	int iCurrentSample = 0;
 
 private:
 	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleRemover;

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -11,13 +11,13 @@ class CScheduler : public CSoundProcessor
 {
 public:
 	CScheduler(float fSampleRate = 0.0f);
-	~CScheduler();
+	virtual ~CScheduler();
 
-	float process() override;
+	virtual float process() override;
 
-	Error_t add(CInstrument* rInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
+	virtual Error_t add(CInstrument* rInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
 
-private:
+protected:
 
 	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleStarter;
 	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleEnder;
@@ -26,5 +26,21 @@ private:
 	int convertSecToSamp(float fSec) const;
 
 	int iCurrentSample = 0;
+};
+
+class CLooper : public CScheduler
+{
+public:
+	CLooper(float fSampleRate = 0.0f);
+	~CLooper();
+
+	float process() override;
+
+	Error_t add(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec) override;
+
+private:
+
+	int iLoopSample = 1;
+
 };
 #endif // #if !defined(__Scheduler_hdr__)

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -11,7 +11,7 @@
 class CScheduler : public CSoundProcessor
 {
 public:
-	CScheduler(float fSampleRate = 0.0f);
+	CScheduler(float fSampleRate = 48000.0f);
 	~CScheduler();
 
 	float process() override;
@@ -40,7 +40,7 @@ private:
 class CLooper : public CScheduler
 {
 public:
-	CLooper(float fSampleRate = 0.0f);
+	CLooper(float fSampleRate = 48000.0f);
 	~CLooper();
 
 	float process() override;

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -1,0 +1,27 @@
+#if !defined(__Scheduler_hdr__)
+#define __Scheduler_hdr__
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "SoundProcessor.h"
+
+class CScheduler : public CSoundProcessor
+{
+public:
+	CScheduler(float fSampleRate);
+	~CScheduler();
+
+	void process();
+
+	Error_t add(CInstrument* rInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
+
+private:
+
+	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleStarter;
+	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleEnder;
+	int convertSecToSamp(float fSec) const;
+
+	int iCurrentSample = 0;
+};
+#endif // #if !defined(__Scheduler_hdr__)

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -13,7 +13,7 @@ public:
 	CScheduler(float fSampleRate = 0.0f);
 	~CScheduler();
 
-	float process();
+	float process() override;
 
 	Error_t add(CInstrument* rInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
 	Error_t enableLoop(bool bShouldEnable);

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -23,8 +23,8 @@ public:
 protected:
 
 	int iCurrentSample = 0;
-	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleNoteOn;
-	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleNoteOff;
+	std::map<int, std::unordered_set<CInstrument*>> m_ScheduleNoteOn;
+	std::map<int, std::unordered_set<CInstrument*>> m_ScheduleNoteOff;
 	std::forward_list<CInstrument*> m_InstrumentList;
 	std::vector<CInstrument*> m_GarbageCollector;
 
@@ -52,7 +52,7 @@ public:
 
 private:
 
-	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleRemover;
+	std::map<int, std::unordered_set<CInstrument*>> m_ScheduleRemover;
 
 	Error_t addToADSRSchedulers(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
 	Error_t addToInstRemover(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec);

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -3,6 +3,7 @@
 
 #include <unordered_map>
 #include <unordered_set>
+#include <forward_list>
 #include <vector>
 
 #include "SoundProcessor.h"
@@ -11,21 +12,25 @@ class CScheduler : public CSoundProcessor
 {
 public:
 	CScheduler(float fSampleRate = 0.0f);
-	virtual ~CScheduler();
+	~CScheduler();
 
-	virtual float process() override;
+	float process() override;
 
-	virtual Error_t add(CInstrument* rInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
+	Error_t add(CInstrument* rInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
+	Error_t reset();
 
 protected:
 
 	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleStarter;
 	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleEnder;
-	std::vector<CInstrument*> m_InstrumentVector;
+	std::forward_list<CInstrument*> m_InstrumentList;
 
 	int convertSecToSamp(float fSec) const;
 
 	int iCurrentSample = 0;
+
+private:
+	std::unordered_map<int, std::unordered_set<CInstrument*>> m_ScheduleDeleter;
 };
 
 class CLooper : public CScheduler
@@ -36,7 +41,8 @@ public:
 
 	float process() override;
 
-	Error_t add(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec) override;
+	Error_t add(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
+	Error_t reset();
 
 private:
 

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -1,7 +1,7 @@
 #if !defined(__Scheduler_hdr__)
 #define __Scheduler_hdr__
 
-#include <unordered_map>
+#include <map>
 #include <unordered_set>
 #include <forward_list>
 #include <vector>

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -16,7 +16,7 @@ public:
 
 	float process() override;
 
-	Error_t add(CInstrument* rInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
+	Error_t add(CInstrument* pInstrumentToAdd, float fOnsetInSec, float fDurationInSec);
 	Error_t reset();
 
 protected:

--- a/src/SoundProcessor.cpp
+++ b/src/SoundProcessor.cpp
@@ -33,6 +33,8 @@ CInstrument::CInstrument(float fGain, float fSampleRate) :
 	CSoundProcessor(fSampleRate)
 {
 	setGain(fGain);
+	m_adsr.setSampleRate(fSampleRate);
+	m_adsr.setParameters(m_adsrParameters);
 }
 
 CInstrument::~CInstrument()
@@ -53,6 +55,42 @@ Error_t CInstrument::setGain(float fNewGain)
 float CInstrument::getGain() const
 {
 	return m_fGain;
+}
+
+Error_t CInstrument::setADSRParameters(float fAttack, float fDecay, float fSustain, float fRelease)
+{
+	m_adsrParameters.attack = fAttack;
+	m_adsrParameters.decay = fDecay;
+	m_adsrParameters.sustain = fSustain;
+	m_adsrParameters.release = fRelease;
+	m_adsr.setParameters(m_adsrParameters);
+	return Error_t::kNoError;
+}
+
+const juce::ADSR::Parameters& CInstrument::getADSRParameters() const
+{
+	return m_adsrParameters;
+}
+
+void CInstrument::noteOn()
+{
+	m_adsr.noteOn();
+}
+
+void CInstrument::noteOff()
+{
+	m_adsr.noteOff();
+}
+
+Error_t CInstrument::setSampleRate(float fNewSampleRate)
+{
+	if (CSoundProcessor::setSampleRate(fNewSampleRate) == Error_t::kNoError)
+	{
+		m_adsr.setSampleRate(fNewSampleRate);
+		m_adsr.setParameters(m_adsrParameters);
+		return Error_t::kNoError;
+	}
+	return Error_t::kFunctionInvalidArgsError;
 }
 //=======================================================================
 
@@ -112,12 +150,12 @@ float CWavetableOscillator::process()
 	if ((m_fCurrentIndex += m_fTableDelta) > (float)m_iTableSize)
 		m_fCurrentIndex -= (float)m_iTableSize;
 
-	return m_fGain * currentSample;
+	return m_adsr.getNextSample() * m_fGain * currentSample;
 }
 
 Error_t CWavetableOscillator::setSampleRate(float fNewSampleRate)
 {
-	if (CSoundProcessor::setSampleRate(fNewSampleRate) == Error_t::kNoError)
+	if (CInstrument::setSampleRate(fNewSampleRate) == Error_t::kNoError)
 		return setFrequency(m_fFrequencyInHz);
 	return Error_t::kFunctionInvalidArgsError;
 }

--- a/src/SoundProcessor.cpp
+++ b/src/SoundProcessor.cpp
@@ -13,8 +13,8 @@ CSoundProcessor::~CSoundProcessor()
 
 Error_t CSoundProcessor::setSampleRate(float fNewSampleRate)
 {
-	assert(fNewSampleRate >= 0.0);
-	if (fNewSampleRate < 0.0)
+	assert(fNewSampleRate > 0.0);
+	if (fNewSampleRate <= 0.0)
 		return Error_t::kFunctionInvalidArgsError;
 
 	m_fSampleRateInHz = fNewSampleRate;

--- a/src/SoundProcessor.cpp
+++ b/src/SoundProcessor.cpp
@@ -100,7 +100,7 @@ CWavetableOscillator::CWavetableOscillator(const CWavetable& wavetableToUse, flo
 	m_Wavetable(wavetableToUse),
 	m_iTableSize(wavetableToUse.getNumSamples())
 {
-	assert(wavetableToUse.hasBeenGenerated());
+	//assert(wavetableToUse.hasBeenGenerated());
 	setFrequency(fFrequency);
 }
 

--- a/src/SoundProcessor.h
+++ b/src/SoundProcessor.h
@@ -19,7 +19,7 @@ public:
 	
 protected:
 
-	float m_fSampleRateInHz = 0.0f;
+	float m_fSampleRateInHz = 48000.0f;
 
 };
 
@@ -49,7 +49,7 @@ protected:
 class CWavetableOscillator : public CInstrument
 {
 public:
-	CWavetableOscillator(const CWavetable& wavetableToUse, float fFrequency, float fGain, float fSampleRate);
+	CWavetableOscillator(const CWavetable& wavetableToUse, float fFrequency = 0.0f, float fGain = 0.0f, float fSampleRate = 48000.0f);
 	virtual ~CWavetableOscillator();
 
 	Error_t setFrequency(float fNewFrequency);

--- a/src/SoundProcessor.h
+++ b/src/SoundProcessor.h
@@ -13,7 +13,7 @@ public:
 
 	virtual float process() = 0;
 
-	virtual Error_t setSampleRate(float fNewSampleRate);
+	virtual Error_t setSampleRate(float fNewSampleRate) = 0;
 	float getSampleRate();
 
 	
@@ -31,10 +31,19 @@ public:
 
 	Error_t setGain(float fNewGain);
 	float getGain() const;
+	Error_t setADSRParameters(float fAttack, float fDecay, float fSustain, float fRelease);
+	const juce::ADSR::Parameters& getADSRParameters() const;
+
+	void noteOn();
+	void noteOff();
+
+	virtual Error_t setSampleRate(float fNewSampleRate) = 0;
 
 protected:
 
 	float m_fGain = 0.0f;
+	juce::ADSR m_adsr;
+	juce::ADSR::Parameters m_adsrParameters;
 };
 
 class CWavetableOscillator : public CInstrument

--- a/src/SoundProcessor.h
+++ b/src/SoundProcessor.h
@@ -11,6 +11,8 @@ public:
 	CSoundProcessor(float fSampleRate);
 	virtual ~CSoundProcessor();
 
+	virtual float process() = 0;
+
 	virtual Error_t setSampleRate(float fNewSampleRate);
 	float getSampleRate();
 
@@ -26,8 +28,6 @@ class CInstrument : public CSoundProcessor
 public:
 	CInstrument(float fGain, float fSampleRate);
 	virtual ~CInstrument();
-
-	virtual float process() = 0;
 
 	Error_t setGain(float fNewGain);
 	float getGain() const;

--- a/src/SoundProcessor.h
+++ b/src/SoundProcessor.h
@@ -11,9 +11,7 @@ public:
 	CSoundProcessor(float fSampleRate);
 	virtual ~CSoundProcessor();
 
-	virtual float process() = 0;
-
-	virtual Error_t setSampleRate(float fNewSampleRate) = 0;
+	virtual Error_t setSampleRate(float fNewSampleRate);
 	float getSampleRate();
 
 	
@@ -28,6 +26,8 @@ class CInstrument : public CSoundProcessor
 public:
 	CInstrument(float fGain, float fSampleRate);
 	virtual ~CInstrument();
+
+	virtual float process() = 0;
 
 	Error_t setGain(float fNewGain);
 	float getGain() const;

--- a/src/Wavetable.h
+++ b/src/Wavetable.h
@@ -10,12 +10,13 @@ public:
 	virtual ~CWavetable() {};
 
     const float* getReadPointer(int sampleIndex = 0) const { return m_fWavetable.getReadPointer(0, sampleIndex); };
-	virtual void generateWavetable() = 0;
     int getNumSamples() const { return s_iTableSize; };
     bool hasBeenGenerated() const { return m_bHasBeenGenerated; };
 
 
 protected:
+
+    virtual void generateWavetable() = 0;
 
 	const unsigned s_iTableSize = 1 << 9;
     juce::AudioSampleBuffer m_fWavetable;
@@ -27,8 +28,10 @@ class CSineWavetable : public CWavetable
 {
 public:
 
-    CSineWavetable() {};
+    CSineWavetable() { generateWavetable(); };
     ~CSineWavetable() {};
+
+protected:
 
 	void generateWavetable() override
 	{


### PR DESCRIPTION
All `CInstrument` classes instances now have an associated ADSR. The `process()` will produce zeros until the `noteOn()` method is called -- this will initiate the adsr. It will hold the sustain level until the `noteOff()` method is called.

The `CScheduler` class acts a container that will trigger `CInstrument` instances at a specified time for a specified duration. It is responsible for the deletion of its contents. It implements three unordered_maps to act as dictionaries for when to trigger certain instruments -- these maps will automatically remove already triggered instruments from themselves. It will also process all its contents and return a float in its `process()` function

The `CLooper` class derives from `CScheduler` and will wrap around to the start of the schedule after completing its last trigger.

closes #26 
closes #25 