### PR TITLE
Set up CMake library for sharing object files between targets, use for GameState.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,11 +72,12 @@ juce_add_gui_app(SoundTests
 # Finally, we supply a list of source files that will be built into the target. This is a standard
 # CMake command.
 
+add_library(Common OBJECT src/GameState.cpp)
+
 target_sources(MusicalChess
     PRIVATE
         src/Main.cpp
         src/MainComponent.cpp
-        src/GameState.cpp
         src/Main.cpp
         src/MainComponent.cpp
         src/SoundProcessor.cpp
@@ -93,17 +94,14 @@ target_sources(MusicalChess
 
 target_sources(Tests
     PRIVATE
-        src/GameState.cpp
         tests/TestGameState.cpp)
 
 target_sources(TerminalChess
     PRIVATE
-        src/GameState.cpp
         tests/TerminalChess.cpp)
 
 target_sources(SonifierTest
 		PRIVATE
-		src/GameState.cpp
 		src/SoundProcessor.cpp
         src/MainProcessor.cpp
         src/Scheduler.cpp
@@ -122,7 +120,6 @@ target_sources(SoundTests
         src/MainProcessor.h
 		src/DebugSonifier.h
 		src/DebugSonifier.cpp
-		src/GameState.cpp
 		src/GameState.h
         tests/soundTests/MainComponent.h
         tests/soundTests/MainComponent.cpp
@@ -178,6 +175,7 @@ target_compile_definitions(SoundTests
 target_link_libraries(MusicalChess
     PRIVATE
         # GuiAppData            # If we'd created a binary data target, we'd link to it here
+        Common
         juce::juce_gui_extra
         juce::juce_audio_utils
     PUBLIC
@@ -185,17 +183,26 @@ target_link_libraries(MusicalChess
         juce::juce_recommended_lto_flags
         juce::juce_recommended_warning_flags)
 
+target_link_libraries(Tests
+    PRIVATE
+        Common)
+
+target_link_libraries(TerminalChess
+    PRIVATE
+        Common)
 
 target_link_libraries(SonifierTest
-		PRIVATE
+    PRIVATE
+        Common
 		juce::juce_audio_processors
-		PUBLIC
+    PUBLIC
 		juce::juce_recommended_config_flags
 		juce::juce_recommended_lto_flags
 		juce::juce_recommended_warning_flags)
 
 target_link_libraries(SoundTests
     PRIVATE
+        Common
         juce::juce_gui_extra
         juce::juce_audio_utils
     PUBLIC


### PR DESCRIPTION
Uses a CMake [object library](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#object-libraries) to represent a set of source files shared between targets. (Note that an "object library" does not actually build a real library, as in a .so/.dll/.a file, but merely represents a collection of .o files.)

Old behavior after modifying `GameState.cpp`:
```
Scanning dependencies of target SoundTests
[  1%] Building CXX object CMakeFiles/SoundTests.dir/src/GameState.cpp.o
[  3%] Linking CXX executable SoundTests_artefacts/SoundTests
[ 32%] Built target SoundTests
Scanning dependencies of target SonifierTest
[ 33%] Building CXX object CMakeFiles/SonifierTest.dir/src/GameState.cpp.o
[ 35%] Linking CXX executable SonifierTest_artefacts/SonifierTest
[ 57%] Built target SonifierTest
Scanning dependencies of target TerminalChess
[ 59%] Building CXX object CMakeFiles/TerminalChess.dir/src/GameState.cpp.o
[ 61%] Linking CXX executable TerminalChess_artefacts/TerminalChess
[ 62%] Built target TerminalChess
Scanning dependencies of target Tests
[ 64%] Building CXX object CMakeFiles/Tests.dir/src/GameState.cpp.o
[ 66%] Linking CXX executable Tests_artefacts/Tests
[ 67%] Built target Tests
Scanning dependencies of target MusicalChess
[ 69%] Building CXX object CMakeFiles/MusicalChess.dir/src/GameState.cpp.o
[ 71%] Linking CXX executable MusicalChess_artefacts/MusicalChess
[100%] Built target MusicalChess
```

New behavior after modifying `GameState.cpp`:
```Scanning dependencies of target Common
[  1%] Building CXX object CMakeFiles/Common.dir/src/GameState.cpp.o
[  1%] Built target Common
[  3%] Linking CXX executable SoundTests_artefacts/SoundTests
[ 34%] Built target SoundTests
[ 36%] Linking CXX executable SonifierTest_artefacts/SonifierTest
[ 60%] Built target SonifierTest
[ 61%] Linking CXX executable TerminalChess_artefacts/TerminalChess
[ 63%] Built target TerminalChess
[ 65%] Linking CXX executable Tests_artefacts/Tests
[ 67%] Built target Tests
[ 69%] Linking CXX executable MusicalChess_artefacts/MusicalChess
[100%] Built target MusicalChess
```

Now, the build only compiles `GameState.cpp` once and then simply relinks the targets that depend on it.

Should be easy to extend to further reduce duplicate effort (and duplicate listing of source files in `CMakeLists.txt`) as needed. (For instance, all sound-related targets can use an object library of sound-related source files.)

Closes #46.