### PR TITLE
Improve Engine UX

### DIFF
--- a/src/BroadcastManager.h
+++ b/src/BroadcastManager.h
@@ -19,6 +19,8 @@ public:
     void changeListenerCallback(juce::ChangeBroadcaster* source) override {
         Game &game = AppState::getInstance().getGame();
         if (game.getTurn() == Color::Black) {
+            // Wait for engine to pick a move in a separate thread,
+            // to avoid blocking the UI.
             task = std::async(std::launch::async, [this, game]{
                 sendActionMessage(engine.analyze(game).bestMove.toString());
             });
@@ -92,12 +94,6 @@ public:
                 juce::Logger::outputDebugString("Legal Move");
                 m_Game.push(move);
                 sendChangeMessage();
-
-                if (engineManager) {
-                    // m_Game.push(mStockfish->analyze(m_Game).bestMove);
-                    // sendChangeMessage();
-                }
-
             }
             else
                 juce::Logger::outputDebugString("Illegal Move");

--- a/src/BroadcastManager.h
+++ b/src/BroadcastManager.h
@@ -18,7 +18,7 @@ public:
         if (shouldTurnOn)
         {
             if (std::filesystem::exists("../stockfish/stockfish_14.1_win_x64_avx2.exe")) {
-                mStockfish = std::make_unique<Stockfish>("../../stockfish/stockfish_14.1_win_x64_avx2.exe");
+                mStockfish = std::make_unique<Chess::Engine>("../../stockfish/stockfish_14.1_win_x64_avx2.exe");
             } else {
                 // Allow user to tell us where their engine binary is.
                 // TODO: Remember their selected engine and allow them to change it later.
@@ -30,7 +30,7 @@ public:
                 engineChooser->launchAsync(chooserFlags, [this](const juce::FileChooser& chooser) {
                     juce::File file = chooser.getResult();
                     if (file.exists()) {
-                        mStockfish = std::make_unique<Stockfish>(file.getFullPathName().toStdString());
+                        mStockfish = std::make_unique<Chess::Engine>(file.getFullPathName().toStdString());
                     }
                 });
             }
@@ -107,7 +107,7 @@ public:
 
 private:
 
-    std::unique_ptr<Stockfish> mStockfish;
+    std::unique_ptr<Chess::Engine> mStockfish;
     std::unique_ptr<juce::FileChooser> engineChooser;
 
     Chess::Game& m_Game = AppState::getInstance().getGame();

--- a/src/EngineBridge.cpp
+++ b/src/EngineBridge.cpp
@@ -48,11 +48,11 @@ void Subprocess::writeline(const std::string &line) {
     fflush(childStdin);
 }
 
-Stockfish::Stockfish(const std::string &path) : process(path) {
+Chess::Engine::Engine(const std::string &path) : process(path) {
     assert(starts_with(process.readline(), "Stockfish"));
 }
 
-Analysis Stockfish::analyze(const Chess::GameState &state, int time) {
+Chess::Analysis Chess::Engine::analyze(const Chess::GameState &state, int time) {
     // Set up the position.
     process.write("position fen ");
     process.writeline(state.getFen());

--- a/src/EngineBridge.h
+++ b/src/EngineBridge.h
@@ -29,19 +29,20 @@ private:
     FILE *childStdin, *childStdout;
 };
 
+namespace Chess {
+    struct Analysis {
+        Chess::Move bestMove;
+        double score;
+    };
 
-struct Analysis {
-    Chess::Move bestMove;
-    double score;
-};
+    class Engine {
+    public:
+        Engine(const std::string &path);
+        Analysis analyze(const Chess::GameState &state, int time=1000);
 
-class Stockfish {
-public:
-    Stockfish(const std::string &path);
-    Analysis analyze(const Chess::GameState &state, int time=1000);
-
-private:
-    Subprocess process;
-};
+    private:
+        Subprocess process;
+    };
+}
 
 #endif

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -402,18 +402,19 @@ void GameState::execute(Move move) {
     // TODO: Update move clocks.
 }
 
-bool Chess::Game::hasNoHistory() const
-{
-    return history.empty();
-}
-
 void Game::push(Move move) {
     // Push the move and a copy of the game state on to the history stack.
     history.emplace(move, GameState(*this));
     execute(move);
 }
 
-Move Game::pop() {
+std::optional<Move> Game::peek() const {
+    if (history.empty()) return std::nullopt;
+    return std::get<0>(history.top());
+}
+
+std::optional<Move> Game::pop() {
+    if (history.empty()) return std::nullopt;
     auto [move, state] = history.top();
     history.pop();
     // TODO: Restore game state in a less hacky way.
@@ -421,9 +422,8 @@ Move Game::pop() {
     setFen(state.getFen());
     return move;
 }
+
 std::unordered_map<Square, std::optional<Piece>> GameState::getThreats() {
-
-
     GameState copy(*this);
     auto pieceMap = copy.getPieceMap();
 

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -162,9 +162,9 @@ namespace Chess {
     class Game: public GameState {
     public:
         using GameState::GameState;
-        bool hasNoHistory() const;
         void push(Move move);
-        Move pop();
+        std::optional<Move> peek() const;
+        std::optional<Move> pop();
 
     private:
         std::stack<std::tuple<Move, GameState>> history;

--- a/tests/TestEngineBridge.cpp
+++ b/tests/TestEngineBridge.cpp
@@ -3,7 +3,7 @@
 
 // TODO: Put this in a test.
 // int main() {
-//     Stockfish engine;
+//     ChessEngine engine;
 //     std::cout << engine.getMove().toString() << std::endl;
 //     std::cout << engine.getMove(100).toString() << std::endl;
 //     return 0;
@@ -12,7 +12,7 @@
 using namespace Chess;
 
 int main(int argc, const char **argv) {
-    Stockfish engine("/usr/games/stockfish");
+    Chess::Engine engine("/usr/games/stockfish");
     Game game(argc > 1 ? argv[1] : Game::initialFen);
 
     auto printBoard = [&game](){
@@ -52,7 +52,7 @@ int main(int argc, const char **argv) {
         }
         printBoard();
         std::cout << "Engine is deciding on a move..." << std::endl;
-        Analysis analysis = engine.analyze(game);
+        Chess::Analysis analysis = engine.analyze(game);
         std::cout << "< " << analysis.bestMove.toString() << " - evaluation (centipawns): " << analysis.score << std::endl;
         assert(game.isLegal(analysis.bestMove));
         game.push(analysis.bestMove);


### PR DESCRIPTION
- Wait for engine's move in a separate thread, to avoid blocking the UI. (Fixes #57.)
- Rename `Stockfish` class to the more generic `Chess::Engine`.
- Allow the user to select the location of their chess engine if it's not in the default location.

Also, remove `Game::hasNoHistory()` and instead wrap `pop()`'s result in `std::optional`. Also add `Game::peek()` for looking at the last move without undoing it.